### PR TITLE
Fix yticklabels in confusion matrix plots

### DIFF
--- a/B1190869_Ezema_Chukwujekwu_ICA_Element_1.py
+++ b/B1190869_Ezema_Chukwujekwu_ICA_Element_1.py
@@ -760,7 +760,7 @@ def predict_model(classifier, X_test, y_test):
     cf_matrix = confusion_matrix(y_test, y_pred, labels=[1,0])
     ax =sns.heatmap(cf_matrix, annot=True, fmt="d", cmap="Blues",
                 xticklabels=['Default', 'Not Default'],
-                yticklabels=['Default', 'NOt Default'])
+                yticklabels=['Default', 'Not Default'])
     ax.set(xlabel="Predicted outputs", ylabel = "Actual outputs")
     plt.show()
 
@@ -919,7 +919,7 @@ def ANN_model(X_train, y_train, X_test, y_test, epochs=5):
     cf_matrix = confusion_matrix(y_test, y_pred, labels=[1,0])
     ax =sns.heatmap(cf_matrix, annot=True, fmt="d", cmap="Blues",
                 xticklabels=['Default', 'Not Default'],
-                yticklabels=['Default', 'NOt Default'])
+                yticklabels=['Default', 'Not Default'])
     ax.set(xlabel="Predicted outputs", ylabel = "Actual outputs")
     plt.show()
 


### PR DESCRIPTION
## Summary
- fix typo in heatmap yticklabels so 'Not Default' is consistent across plots

## Testing
- `python -m py_compile B1190869_Ezema_Chukwujekwu_ICA_Element_1.py`

------
https://chatgpt.com/codex/tasks/task_e_684048f2d4c4832494cea03b9555f41a