### PR TITLE
Fix typo in PCA comment

### DIFF
--- a/B1190869_Ezema_Chukwujekwu_ICA_Element_1.py
+++ b/B1190869_Ezema_Chukwujekwu_ICA_Element_1.py
@@ -569,7 +569,7 @@ print("After OverSampling, counts of non-default: {}".format(sum(y_train_sm==0))
 # In[32]:
 
 
-#3.7 Dimentionality reduction stratgey for feature selection
+#3.7 Dimensionality reduction strategy for feature selection
 def apply_PCA(X_train, X_test, COMPONENTS=10):
 
     # Tranform X train, X test


### PR DESCRIPTION
## Summary
- correct spelling typo in ICA element script

## Testing
- `python -m py_compile B1190869_Ezema_Chukwujekwu_ICA_Element_1.py`

------
https://chatgpt.com/codex/tasks/task_e_6840490a7400832499d01cbcfbc7b885