### PR TITLE
Add unit test for transform_target

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_transform_target.py
+++ b/tests/test_transform_target.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pandas.testing as pdt
+
+from B1190869_Ezema_Chukwujekwu_ICA_Element_1 import transform_target
+
+
+def test_transform_target_basic():
+    df = pd.DataFrame({
+        'ID': [1, 1, 2, 2, 3],
+        'STATUS': ['X', '2', '0', 'C', '1']
+    })
+    result = transform_target(df)
+    result = result.sort_values('ID').reset_index(drop=True)
+    expected = pd.DataFrame({
+        'ID': [1, 2, 3],
+        'Target': [0, 0, 1]
+    })
+    pdt.assert_frame_equal(result, expected)
+


### PR DESCRIPTION
## Summary
- add `pytest.ini` to configure pytest to run tests from the `tests` folder
- create `tests/test_transform_target.py` with a small DataFrame test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840490f51dc83249102c1b481e0c8d4