### PR TITLE
Fix XGBoost grid search parameters

### DIFF
--- a/B1190869_Ezema_Chukwujekwu_ICA_Element_1.py
+++ b/B1190869_Ezema_Chukwujekwu_ICA_Element_1.py
@@ -711,11 +711,17 @@ def model_best_estimator(X_train, y_train, class_weight=None, random_state=rando
     
     # XGBoost Classifier
     t8 = time.time()
-    XGB_params_grid = {"criterion": ["gini", "entropy"], "max_depth": list(range(2,6,1)),
-                "min_samples_leaf": list(range(2,7,1))}
+    XGB_params_grid = {
+        "max_depth": list(range(2, 6, 1)),
+        "learning_rate": [0.01, 0.1, 0.2],
+        "n_estimators": [100, 200]
+    }
 
-    grid_XGB = GridSearchCV(XGBClassifier(random_state=random_state, class_weight=class_weight), 
-                           XGB_params_grid, cv=cv)
+    grid_XGB = GridSearchCV(
+        XGBClassifier(random_state=random_state),
+        XGB_params_grid,
+        cv=cv
+    )
     grid_XGB.fit(X_train, y_train)
 
     # random forest best estimator


### PR DESCRIPTION
## Summary
- fix invalid parameter grid for XGBClassifier in ICA element script

## Testing
- `python -m py_compile B1190869_Ezema_Chukwujekwu_ICA_Element_1.py`

------
https://chatgpt.com/codex/tasks/task_e_6840146dffd08324abc921360ddff9c1